### PR TITLE
Feat: Add local voice prompting with whisper-rs and UI 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ dist-ssr
 # Tauri / Rust artifacts
 src-tauri/target
 src-tauri/gen
+# Local speech-to-text assets (downloaded at runtime)
+src-tauri/models/
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Desktop app scaffold for an agentic development environment (Codex-Desktop style
   - `Git + PR` (diff, AI commit message, commit, create PR mock)
   - `Terminal` (session create/write/close)
   - `Automation` (placeholder surface)
+  - `Voice Prompting` (local microphone capture + Whisper transcription via Tauri commands/events)
 - Typed command envelope used across FE and Tauri commands:
   - `CommandResult<T> = { ok: true; data: T } | { ok: false; error: { code: string; message: string } }`
 - Mock service adapters and state store for clickable end-to-end flows
@@ -23,20 +24,29 @@ Desktop app scaffold for an agentic development environment (Codex-Desktop style
 - Node.js 22+
 - npm 10+
 - Rust 1.77+
+- CMake (required to build `whisper-rs-sys`)
 
 ### Tauri system dependencies
 
 - macOS: Xcode Command Line Tools
-- Windows: Visual Studio Build Tools + WebView2
+- Windows: Visual Studio Build Tools + WebView2 + CMake
 - Linux (Ubuntu/Debian):
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y \
+  build-essential \
+  cmake \
   libwebkit2gtk-4.1-dev \
   libappindicator3-dev \
   librsvg2-dev \
   patchelf
+```
+
+macOS (Homebrew):
+
+```bash
+brew install cmake
 ```
 
 ## Quick start
@@ -45,6 +55,11 @@ sudo apt-get install -y \
 npm i
 npm run tauri:dev
 ```
+
+First launch with voice enabled:
+
+- The app auto-downloads Whisper model `ggml-base.en.bin` (local only, no cloud STT).
+- Model and recordings are stored in the app data directory (not inside `src-tauri`, so dev mode does not auto-restart on each recording).
 
 Alternative web-only UI run:
 
@@ -71,6 +86,23 @@ npm run dev
 - `src/state/*`: app store + context/actions
 - `src/features/*`: page-level feature modules
 - `src-tauri/src/lib.rs`: native command stubs and Tauri setup
+- `src/hooks/useVoice.ts`: FE voice integration (invoke + listen events)
+- `src-tauri/src/commands/voice.rs`: `start_recording`, `stop_recording`, `transcribe_audio`
+- `src-tauri/src/audio/recorder.rs`: local microphone capture with `cpal` and WAV output
+- `src-tauri/src/stt/whisper.rs`: local Whisper inference via `whisper-rs`
+- `src-tauri/src/stt/model_download.rs`: first-run model download to app data
+
+## Voice-to-Text (local)
+
+This project runs speech-to-text fully local using `whisper-rs` + `cpal`:
+
+- Click mic -> `start_recording` starts microphone capture.
+- Click again -> `stop_recording` writes WAV file.
+- `transcribe_audio` runs Whisper in background and emits `voice_result`.
+- Frontend listens to `voice_result` and injects transcript into chat draft.
+- Frontend also listens to realtime `voice_level` for waveform animation while recording.
+
+No cloud speech API is used.
 
 ## Environment variables
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -44,6 +44,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +183,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -203,7 +225,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -229,7 +251,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -298,6 +320,47 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -557,6 +620,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -565,6 +630,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfb"
@@ -618,6 +692,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +748,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -675,9 +779,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -688,8 +792,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen 0.72.1",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -819,6 +966,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "deranged"
@@ -1005,6 +1158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1182,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1190,12 +1358,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1211,6 +1388,12 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
@@ -1223,6 +1406,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1247,6 +1436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1638,6 +1828,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1893,21 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "html5ever"
@@ -1756,6 +1980,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1765,6 +1990,38 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1785,9 +2042,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1987,6 +2246,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2313,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2099,6 +2386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2145,6 +2438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2455,12 @@ checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2188,6 +2497,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -2262,6 +2580,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2628,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,7 +2667,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2323,6 +2678,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -2371,10 +2735,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -2383,6 +2768,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2569,10 +2964,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2902,7 +3364,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3264,6 +3726,48 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3320,6 +3824,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3352,14 +3870,21 @@ dependencies = [
 name = "rocknroll"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "cpal",
+ "hound",
  "log",
+ "num_cpus",
+ "once_cell",
  "portable-pty",
+ "reqwest 0.12.28",
  "rfd",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -3380,6 +3905,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -3395,6 +3926,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3402,8 +3946,41 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3413,12 +3990,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3485,6 +4077,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3516,7 +4131,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "servo_arc 0.4.3",
  "smallvec",
 ]
@@ -3624,6 +4239,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3817,7 +4444,7 @@ checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
  "js-sys",
- "ndk",
+ "ndk 0.9.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3925,6 +4552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3978,6 +4611,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3998,7 +4652,7 @@ checksum = "6e06d52c379e63da659a483a958110bbde891695a0ecb53e48cc7786d5eda7bb"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -4010,9 +4664,9 @@ dependencies = [
  "jni",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -4022,7 +4676,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4081,7 +4735,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4099,7 +4753,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4226,7 +4880,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4251,7 +4905,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4313,7 +4967,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4438,6 +5092,26 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4745,6 +5419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4810,6 +5490,12 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5072,7 +5758,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5096,8 +5782,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "whisper-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e19ccc66e3746fc15cc9b8cbc67be61d7326f0dd313c3d5dce53e706365e23"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91adc462e9bc7b3fce6116eeafe76f9bc46c20c2b4f5fe0da00fd1196fa92f1"
+dependencies = [
+ "bindgen 0.69.5",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
 ]
 
 [[package]]
@@ -5148,6 +5867,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5166,6 +5895,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5247,6 +5986,26 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5751,7 +6510,7 @@ dependencies = [
  "javascriptcore-rs",
  "jni",
  "libc",
- "ndk",
+ "ndk 0.9.0",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -5769,7 +6528,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5940,6 +6699,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,3 +23,10 @@ tauri = { version = "2.10.3", features = [] }
 tauri-plugin-log = "2"
 portable-pty = "0.9"
 rfd = "0.14"
+cpal = "0.15"
+hound = "3"
+whisper-rs = "0.10"
+once_cell = "1.19"
+anyhow = "1.0"
+num_cpus = "1.16"
+reqwest = { version = "0.12", features = ["blocking"] }

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,0 +1,2 @@
+pub mod recorder;
+

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -1,0 +1,299 @@
+use std::{
+    path::PathBuf,
+    sync::{mpsc, Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::{anyhow, Context, Result};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use hound::{SampleFormat, WavSpec, WavWriter};
+
+struct RecordingHandle {
+    stop_tx: mpsc::Sender<()>,
+    finished_rx: mpsc::Receiver<Result<PathBuf, String>>,
+}
+
+pub struct RecorderManager {
+    inner: Mutex<Option<RecordingHandle>>,
+}
+
+impl RecorderManager {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+
+    pub fn start_recording(
+        &self,
+        output_path: PathBuf,
+        level_tx: Option<mpsc::SyncSender<f32>>,
+    ) -> Result<()> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| anyhow!("Failed to lock recorder manager"))?;
+
+        if guard.is_some() {
+            return Ok(());
+        }
+
+        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+        let (finished_tx, finished_rx) = mpsc::channel::<Result<PathBuf, String>>();
+
+        thread::spawn(move || {
+            let result =
+                run_recording(stop_rx, output_path, level_tx).map_err(|err| err.to_string());
+            let _ = finished_tx.send(result);
+        });
+
+        *guard = Some(RecordingHandle {
+            stop_tx,
+            finished_rx,
+        });
+
+        Ok(())
+    }
+
+    pub fn stop_and_save(&self) -> Result<PathBuf> {
+        let handle = {
+            let mut guard = self
+                .inner
+                .lock()
+                .map_err(|_| anyhow!("Failed to lock recorder manager"))?;
+            guard.take().ok_or_else(|| anyhow!("Not recording"))?
+        };
+
+        handle
+            .stop_tx
+            .send(())
+            .map_err(|_| anyhow!("Failed to signal stop to recorder"))?;
+
+        let result = handle
+            .finished_rx
+            .recv()
+            .map_err(|_| anyhow!("Failed to receive recording result"))?;
+
+        result.map_err(|err| anyhow!(err))
+    }
+}
+
+fn run_recording(
+    stop_rx: mpsc::Receiver<()>,
+    out_path: PathBuf,
+    level_tx: Option<mpsc::SyncSender<f32>>,
+) -> Result<PathBuf> {
+    let host = cpal::default_host();
+    let device = host
+        .default_input_device()
+        .ok_or_else(|| anyhow!("No default input device available"))?;
+
+    let supported_config = device
+        .default_input_config()
+        .context("Failed to get default input config")?;
+
+    let sample_format = supported_config.sample_format();
+    let config: cpal::StreamConfig = supported_config.into();
+
+    let sample_rate = config.sample_rate.0;
+    let channels = config.channels;
+
+    let samples: Arc<Mutex<Vec<i16>>> = Arc::new(Mutex::new(Vec::new()));
+    let last_level_emit = Arc::new(Mutex::new(
+        Instant::now()
+            .checked_sub(Duration::from_millis(100))
+            .unwrap_or_else(Instant::now),
+    ));
+
+    let stream = match sample_format {
+        cpal::SampleFormat::I16 => {
+            let samples_clone = samples.clone();
+            let level_tx = level_tx.clone();
+            let last_level_emit = last_level_emit.clone();
+            device.build_input_stream(
+                &config,
+                move |data: &[i16], _| {
+                    if let Ok(mut buf) = samples_clone.lock() {
+                        buf.extend_from_slice(data);
+                    }
+                    try_emit_level_i16(data, &level_tx, &last_level_emit);
+                },
+                move |err| {
+                    eprintln!("[Recorder] Stream error: {err}");
+                },
+                None,
+            )?
+        }
+        cpal::SampleFormat::U16 => {
+            let samples_clone = samples.clone();
+            let level_tx = level_tx.clone();
+            let last_level_emit = last_level_emit.clone();
+            device.build_input_stream(
+                &config,
+                move |data: &[u16], _| {
+                    if let Ok(mut buf) = samples_clone.lock() {
+                        buf.extend(data.iter().map(|s| {
+                            let v = *s as i32 - i16::MAX as i32;
+                            v.max(i16::MIN as i32).min(i16::MAX as i32) as i16
+                        }));
+                    }
+                    try_emit_level_u16(data, &level_tx, &last_level_emit);
+                },
+                move |err| {
+                    eprintln!("[Recorder] Stream error: {err}");
+                },
+                None,
+            )?
+        }
+        cpal::SampleFormat::F32 => {
+            let samples_clone = samples.clone();
+            let level_tx = level_tx.clone();
+            let last_level_emit = last_level_emit.clone();
+            device.build_input_stream(
+                &config,
+                move |data: &[f32], _| {
+                    if let Ok(mut buf) = samples_clone.lock() {
+                        buf.extend(data.iter().map(|s| {
+                            let v = (s * i16::MAX as f32) as i32;
+                            v.max(i16::MIN as i32).min(i16::MAX as i32) as i16
+                        }));
+                    }
+                    try_emit_level_f32(data, &level_tx, &last_level_emit);
+                },
+                move |err| {
+                    eprintln!("[Recorder] Stream error: {err}");
+                },
+                None,
+            )?
+        }
+        _ => {
+            return Err(anyhow!(
+                "Unsupported input sample format: {:?}",
+                sample_format
+            ));
+        }
+    };
+
+    stream.play()?;
+
+    let _ = stop_rx.recv();
+
+    drop(stream);
+
+    let recorded_samples = {
+        let mut guard = samples
+            .lock()
+            .map_err(|_| anyhow!("Failed to lock samples buffer"))?;
+        std::mem::take(&mut *guard)
+    };
+
+    let out_dir = out_path
+        .parent()
+        .ok_or_else(|| anyhow!("Recording output path has no parent directory"))?;
+    std::fs::create_dir_all(out_dir)?;
+
+    let spec = WavSpec {
+        channels,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+
+    let mut writer = WavWriter::create(&out_path, spec)?;
+    for sample in recorded_samples {
+        writer.write_sample(sample)?;
+    }
+    writer.finalize()?;
+
+    Ok(out_path)
+}
+
+fn should_emit_level(last_level_emit: &Arc<Mutex<Instant>>) -> bool {
+    if let Ok(mut last_emit) = last_level_emit.lock() {
+        if last_emit.elapsed() < Duration::from_millis(45) {
+            return false;
+        }
+        *last_emit = Instant::now();
+        return true;
+    }
+    false
+}
+
+fn try_send_level(level_tx: &Option<mpsc::SyncSender<f32>>, level: f32) {
+    if let Some(tx) = level_tx {
+        let clamped = level.clamp(0.0, 1.0);
+        let _ = tx.try_send(clamped);
+    }
+}
+
+fn rms_from_f32(data: &[f32]) -> f32 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = data.iter().map(|s| s * s).sum();
+    (sum / data.len() as f32).sqrt()
+}
+
+fn rms_from_i16(data: &[i16]) -> f32 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = data
+        .iter()
+        .map(|s| {
+            let v = *s as f32 / i16::MAX as f32;
+            v * v
+        })
+        .sum();
+    (sum / data.len() as f32).sqrt()
+}
+
+fn rms_from_u16(data: &[u16]) -> f32 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = data
+        .iter()
+        .map(|s| {
+            let v = ((*s as f32 / u16::MAX as f32) * 2.0) - 1.0;
+            v * v
+        })
+        .sum();
+    (sum / data.len() as f32).sqrt()
+}
+
+fn try_emit_level_i16(
+    data: &[i16],
+    level_tx: &Option<mpsc::SyncSender<f32>>,
+    last_level_emit: &Arc<Mutex<Instant>>,
+) {
+    if !should_emit_level(last_level_emit) || data.is_empty() {
+        return;
+    }
+    try_send_level(level_tx, rms_from_i16(data));
+}
+
+fn try_emit_level_u16(
+    data: &[u16],
+    level_tx: &Option<mpsc::SyncSender<f32>>,
+    last_level_emit: &Arc<Mutex<Instant>>,
+) {
+    if !should_emit_level(last_level_emit) || data.is_empty() {
+        return;
+    }
+    try_send_level(level_tx, rms_from_u16(data));
+}
+
+fn try_emit_level_f32(
+    data: &[f32],
+    level_tx: &Option<mpsc::SyncSender<f32>>,
+    last_level_emit: &Arc<Mutex<Instant>>,
+) {
+    if !should_emit_level(last_level_emit) || data.is_empty() {
+        return;
+    }
+    try_send_level(level_tx, rms_from_f32(data));
+}
+
+

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub mod voice;
+

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -1,0 +1,90 @@
+use std::path::PathBuf;
+
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::audio::recorder::RecorderManager;
+use crate::stt::model_download::{
+    ensure_model_exists_at, MODEL_FILE_NAME, RECORDING_FILE_NAME, VOICE_DIR_NAME,
+};
+use crate::stt::whisper::transcribe_wav_file;
+
+static RECORDER_MANAGER: once_cell::sync::Lazy<RecorderManager> =
+    once_cell::sync::Lazy::new(RecorderManager::new);
+
+fn resolve_voice_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let base_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data directory: {e}"))?;
+    Ok(base_dir.join(VOICE_DIR_NAME))
+}
+
+fn resolve_recording_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(resolve_voice_dir(app)?.join(RECORDING_FILE_NAME))
+}
+
+fn resolve_model_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(resolve_voice_dir(app)?.join(MODEL_FILE_NAME))
+}
+
+#[tauri::command]
+pub async fn start_recording(app: AppHandle) -> Result<(), String> {
+    let recording_path = resolve_recording_path(&app)?;
+    let (level_tx, level_rx) = std::sync::mpsc::sync_channel::<f32>(8);
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        for level in level_rx {
+            if let Err(err) = app_clone.emit("voice_level", level) {
+                eprintln!("[voice] Failed to emit voice_level: {err}");
+                break;
+            }
+        }
+        let _ = app_clone.emit("voice_level", 0.0_f32);
+    });
+
+    RECORDER_MANAGER
+        .start_recording(recording_path, Some(level_tx))
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn stop_recording() -> Result<(), String> {
+    RECORDER_MANAGER
+        .stop_and_save()
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn transcribe_audio(app: AppHandle) -> Result<(), String> {
+    let model_path = resolve_model_path(&app)?;
+    let recording_path = resolve_recording_path(&app)?;
+
+    let app_clone = app.clone();
+
+    tauri::async_runtime::spawn_blocking(move || {
+        if let Err(err) = ensure_model_exists_at(&model_path) {
+            eprintln!("[voice] Failed to ensure model exists: {err}");
+            let _ = app_clone.emit("voice_result", format!("(transcription error: {err})"));
+            return;
+        }
+
+        match transcribe_wav_file(model_path, recording_path) {
+            Ok(transcript) => {
+                if let Err(err) = app_clone.emit("voice_result", transcript) {
+                    eprintln!("[voice] Failed to emit voice_result: {err}");
+                }
+            }
+            Err(err) => {
+                eprintln!("[voice] Transcription failed: {err}");
+                let _ = app_clone.emit(
+                    "voice_result",
+                    format!("(transcription error: {err})"),
+                );
+            }
+        }
+    });
+
+    Ok(())
+}
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,11 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
+
+mod audio;
+mod commands;
+mod stt;
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -441,6 +445,16 @@ pub fn run() {
                         .build(),
                 )?;
             }
+            let model_path = app
+                .path()
+                .app_data_dir()?
+                .join(crate::stt::model_download::VOICE_DIR_NAME)
+                .join(crate::stt::model_download::MODEL_FILE_NAME);
+            tauri::async_runtime::spawn_blocking(move || {
+                if let Err(err) = crate::stt::model_download::ensure_model_exists_at(&model_path) {
+                    eprintln!("[voice] Failed to ensure Whisper model: {err}");
+                }
+            });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -453,7 +467,10 @@ pub fn run() {
             list_terminal_sessions,
             write_terminal_session,
             resize_terminal_session,
-            close_terminal_session
+            close_terminal_session,
+            crate::commands::voice::start_recording,
+            crate::commands::voice::stop_recording,
+            crate::commands::voice::transcribe_audio,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/stt/mod.rs
+++ b/src-tauri/src/stt/mod.rs
@@ -1,0 +1,3 @@
+pub mod whisper;
+pub mod model_download;
+

--- a/src-tauri/src/stt/model_download.rs
+++ b/src-tauri/src/stt/model_download.rs
@@ -1,0 +1,40 @@
+use std::{fs, io::Write, path::Path};
+
+use anyhow::{Context, Result};
+
+const MODEL_URL: &str =
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin";
+pub const VOICE_DIR_NAME: &str = "voice";
+pub const MODEL_FILE_NAME: &str = "ggml-base.en.bin";
+pub const RECORDING_FILE_NAME: &str = "latest.wav";
+
+pub fn ensure_model_exists_at(path: &Path) -> Result<()> {
+
+    if path.exists() {
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create model dir {:?}", parent))?;
+    }
+
+    let resp = reqwest::blocking::get(MODEL_URL)
+        .context("Failed to download Whisper model")?;
+
+    if !resp.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "Failed to download model, status: {}",
+            resp.status()
+        ));
+    }
+
+    let bytes = resp.bytes().context("Failed to read model bytes")?;
+    let mut file =
+        fs::File::create(path).with_context(|| format!("Failed to create model file at {:?}", path))?;
+    file.write_all(&bytes)
+        .context("Failed to write model file")?;
+
+    Ok(())
+}
+

--- a/src-tauri/src/stt/whisper.rs
+++ b/src-tauri/src/stt/whisper.rs
@@ -1,0 +1,115 @@
+use std::{path::Path, sync::Mutex};
+
+use anyhow::{anyhow, Context, Result};
+use hound;
+use once_cell::sync::Lazy;
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+static WHISPER_CTX: Lazy<Mutex<Option<WhisperContext>>> = Lazy::new(|| Mutex::new(None));
+
+fn ensure_model_loaded(model_path: &Path) -> Result<()> {
+    let mut guard = WHISPER_CTX
+        .lock()
+        .map_err(|_| anyhow!("Failed to lock Whisper context"))?;
+
+    if guard.is_none() {
+        let model_path_str = model_path.to_string_lossy();
+        let ctx = WhisperContext::new_with_params(&model_path_str, WhisperContextParameters::new())
+            .with_context(|| format!("Failed to load Whisper model at {:?}", model_path))?;
+        *guard = Some(ctx);
+    }
+
+    Ok(())
+}
+
+pub fn transcribe_wav_file<P: AsRef<Path>>(model_path: P, wav_path: P) -> Result<String> {
+    let model_path = model_path.as_ref().to_path_buf();
+    let wav_path = wav_path.as_ref().to_path_buf();
+
+    ensure_model_loaded(&model_path)?;
+
+    let mut reader = hound::WavReader::open(&wav_path)
+        .with_context(|| format!("Failed to open WAV file {:?}", wav_path))?;
+
+    let spec = reader.spec();
+    if spec.channels != 1 {
+        return Err(anyhow!(
+            "Expected mono audio, but got {} channels",
+            spec.channels
+        ));
+    }
+
+    let samples: Result<Vec<f32>> = reader
+        .samples::<i16>()
+        .map(|s| s.map(|x| x as f32 / i16::MAX as f32).map_err(anyhow::Error::from))
+        .collect();
+    let audio = samples?;
+
+    let audio = if spec.sample_rate != 16_000 {
+        simple_linear_resample(&audio, spec.sample_rate, 16_000)
+    } else {
+        audio
+    };
+
+    let mut guard = WHISPER_CTX
+        .lock()
+        .map_err(|_| anyhow!("Failed to lock Whisper context"))?;
+
+    let ctx = guard
+        .as_mut()
+        .ok_or_else(|| anyhow!("Whisper model not initialized"))?;
+
+    let mut state = ctx
+        .create_state()
+        .context("Failed to create Whisper state")?;
+
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+    params.set_language(Some("en"));
+    params.set_n_threads(num_cpus::get().max(1) as i32);
+
+    state
+        .full(params, &audio)
+        .context("Failed to run Whisper full()")?;
+
+    let num_segments = state
+        .full_n_segments()
+        .context("Failed to get number of segments")?;
+
+    let mut transcript = String::new();
+    for i in 0..num_segments {
+        let segment = state
+            .full_get_segment_text(i)
+            .context("Failed to get segment text")?;
+        transcript.push_str(&segment);
+        transcript.push(' ');
+    }
+
+    Ok(transcript.trim().to_string())
+}
+
+fn simple_linear_resample(input: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
+    if input.is_empty() || from_rate == to_rate {
+        return input.to_vec();
+    }
+
+    let ratio = to_rate as f32 / from_rate as f32;
+    let out_len = (input.len() as f32 * ratio).round() as usize;
+    let mut out = Vec::with_capacity(out_len);
+
+    for i in 0..out_len {
+        let t = i as f32 / ratio;
+        let idx = t.floor() as usize;
+        let frac = t - idx as f32;
+
+        if idx + 1 < input.len() {
+            let a = input[idx];
+            let b = input[idx + 1];
+            out.push(a + (b - a) * frac);
+        } else {
+            out.push(*input.last().unwrap());
+        }
+    }
+
+    out
+}
+

--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+
+export function useVoice() {
+  const [isRecording, setIsRecording] = useState(false)
+  const [isTranscribing, setIsTranscribing] = useState(false)
+  const [voiceLevel, setVoiceLevel] = useState(0)
+  const [transcript, setTranscript] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let unlistenResult: UnlistenFn | null = null
+    let unlistenLevel: UnlistenFn | null = null
+
+    const setup = async () => {
+      try {
+        unlistenResult = await listen<string>('voice_result', (event) => {
+          setTranscript(event.payload)
+          setIsTranscribing(false)
+          setVoiceLevel(0)
+        })
+        unlistenLevel = await listen<number>('voice_level', (event) => {
+          setVoiceLevel(event.payload ?? 0)
+        })
+      } catch (e) {
+        console.error('Failed to listen to voice events', e)
+      }
+    }
+
+    void setup()
+
+    return () => {
+      unlistenResult?.()
+      unlistenLevel?.()
+    }
+  }, [])
+
+  const startRecording = async () => {
+    setError(null)
+    try {
+      await invoke('start_recording')
+      setIsRecording(true)
+      setVoiceLevel(0)
+      setTranscript(null)
+    } catch (e: any) {
+      console.error('Failed to start recording', e)
+      setError(e?.toString?.() ?? 'Failed to start recording')
+    }
+  }
+
+  const stopRecording = async () => {
+    setError(null)
+    try {
+      await invoke('stop_recording')
+      setIsRecording(false)
+      setIsTranscribing(true)
+      setVoiceLevel(0)
+      await invoke('transcribe_audio')
+    } catch (e: any) {
+      console.error('Failed to stop or transcribe', e)
+      setError(e?.toString?.() ?? 'Failed to stop or transcribe')
+      setIsRecording(false)
+      setIsTranscribing(false)
+      setVoiceLevel(0)
+    }
+  }
+
+  return {
+    isRecording,
+    isTranscribing,
+    voiceLevel,
+    transcript,
+    error,
+    startRecording,
+    stopRecording,
+  }
+}
+

--- a/src/ui/chat/chat-input.tsx
+++ b/src/ui/chat/chat-input.tsx
@@ -1,5 +1,14 @@
-import { useState } from 'react'
-import { ArrowUp, Check, ChevronDown, Cpu, Gauge, Mic, Plus } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  ArrowUp,
+  Check,
+  ChevronDown,
+  Cpu,
+  Gauge,
+  LoaderCircle,
+  Mic,
+  Plus,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -12,6 +21,7 @@ import {
 import { Textarea } from '@/components/ui/textarea'
 import type { EffortLevel } from '../../domain/contracts'
 import { useAppStore } from '../../state/app-store-context'
+import { useVoice } from '../../hooks/useVoice'
 
 const models = [
   { id: 'claude-opus-4-6', label: 'Opus 4.6' },
@@ -24,6 +34,20 @@ const efforts: EffortLevel[] = ['low', 'medium', 'high', 'extra-high']
 export const ChatInput = () => {
   const { state, actions } = useAppStore()
   const [draft, setDraft] = useState('')
+  const {
+    isRecording,
+    isTranscribing,
+    voiceLevel,
+    transcript,
+    startRecording,
+    stopRecording,
+  } = useVoice()
+
+  useEffect(() => {
+    if (transcript && !isRecording && !isTranscribing) {
+      setDraft((prev) => (prev ? `${prev} ${transcript}` : transcript))
+    }
+  }, [transcript, isRecording, isTranscribing])
 
   const handleSend = () => {
     const content = draft.trim()
@@ -51,6 +75,11 @@ export const ChatInput = () => {
       .split('-')
       .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
       .join(' ')
+
+  const voiceStrength = Math.min(1, Math.sqrt(Math.max(0, voiceLevel)))
+  const waveformHeights = [0.25, 0.4, 0.6, 0.85, 1, 0.85, 0.6, 0.4, 0.25].map(
+    (multiplier) => Math.round(3 + 16 * voiceStrength * multiplier),
+  )
 
   return (
     <div className="bg-background px-5 pb-3 pt-4">
@@ -172,16 +201,50 @@ export const ChatInput = () => {
               </DropdownMenu>
             </div>
 
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-2">
+              {isRecording && (
+                <span className="inline-flex items-center rounded-full bg-muted px-3 py-1">
+                  <span className="inline-flex h-5 items-end gap-[3px]" aria-hidden="true">
+                    {waveformHeights.map((height, index) => (
+                      <span
+                        key={`voice-wave-${index}`}
+                        className="w-[3px] rounded-full bg-red-500 transition-[height] duration-75"
+                        style={{ height: `${height}px` }}
+                      />
+                    ))}
+                  </span>
+                </span>
+              )}
               <Button
                 type="button"
                 size="icon-lg"
                 variant="ghost"
-                className="rounded-full text-muted-foreground"
+                className={`relative rounded-full text-muted-foreground transition ${
+                  isRecording ? 'bg-red-50 text-red-500 dark:bg-red-950/20' : ''
+                }`}
                 title="Voice input"
+                onClick={() => {
+                  if (!state.activeThreadId) return
+                  if (isRecording) {
+                    void stopRecording()
+                  } else {
+                    void startRecording()
+                  }
+                }}
+                disabled={!state.activeThreadId || isTranscribing}
               >
-                <Mic className="size-5" />
-                <span className="sr-only">Voice input</span>
+                {isTranscribing ? (
+                  <LoaderCircle className="size-5 animate-spin" />
+                ) : (
+                  <Mic className={`size-5 ${isRecording ? 'animate-pulse text-red-500' : ''}`} />
+                )}
+                <span className="sr-only">
+                  {isTranscribing
+                    ? 'Transcribing voice input'
+                    : isRecording
+                      ? 'Stop voice input'
+                      : 'Start voice input'}
+                </span>
               </Button>
               <Button
                 type="button"


### PR DESCRIPTION
## Summary

- Add local voice prompting (offline) using `cpal` + `whisper-rs`.
- Implement Tauri voice commands (`start_recording`, `stop_recording`, `transcribe_audio`) and emit `voice_result` / `voice_level`.
- Integrate frontend mic flow via `useVoice` and add realtime waveform animation in chat input.
- Move model/recording runtime files to app data directory and add first-run auto-download for Whisper model.
- Remove tracked model binary from source and update `.gitignore` / README.

## Test plan

- [ ] `cargo build` passes in `src-tauri` folder 
- [ ] `npm run build` passes
- [ ] `npm run tauri:dev` starts normally
- [ ] Mic click -> recording starts and waveform reacts to voice level
- [ ] Mic click again -> transcription completes and transcript appears in input
- [ ] App does not restart during recording in dev mode